### PR TITLE
fix: Resolve docker-compose configuration issues and update documenta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ cp .env.example .env
 # Edit .env with your passwords (see Configuration section)
 ```
 
-### 2. Deploy with Docker Compose
+### 2. Choose Your Deployment Mode
 
+QuickBuild provides **4 docker-compose configurations** for different scenarios:
+
+#### **Option A: Development Mode** (Recommended for testing)
 ```bash
-# Start the complete stack
-docker-compose up -d
+# Start with development settings (debug enabled, exposed ports, local volumes)
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 # Verify deployment
 ./scripts/validate-deployment.sh -e docker-compose
@@ -58,6 +61,26 @@ docker-compose up -d
 # Monitor status
 ./scripts/monitor.sh -e docker-compose --once
 ```
+
+#### **Option B: Production Mode**
+```bash
+# Start with production settings (secrets, TLS, higher resources)
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+#### **Option C: Scaling Mode**
+```bash
+# Start with advanced scaling capabilities
+docker-compose -f docker-compose.yml -f docker-compose.scale.yml up -d
+```
+
+#### **Option D: Basic Mode** (Testing only)
+```bash
+# Start with base configuration only (not optimized)
+docker-compose up -d
+```
+
+> **💡 Tip:** For development, use **Option A**. For production deployments, use **Option B**.
 
 ### 3. Access QuickBuild
 
@@ -80,29 +103,43 @@ docker-compose up -d
 
 That's it! Your QuickBuild 14 environment is ready for use.
 
-### Prerequisites
+## 📊 Docker Compose Configurations Explained
 
-- Docker Engine 20.10+
-- Docker Compose 2.0+
-- 4GB+ available RAM
-- 20GB+ available disk space
+This project includes **4 docker-compose files** that can be combined for different deployment scenarios:
 
-### Basic Setup
+| File | Purpose | When to Use |
+|------|---------|-------------|
+| **docker-compose.yml** | Base configuration with all services | Always required (base layer) |
+| **docker-compose.dev.yml** | Development overrides | Local development and testing |
+| **docker-compose.prod.yml** | Production overrides | Production deployments |
+| **docker-compose.scale.yml** | Advanced scaling config | High-load environments |
 
-```bash
-# Clone the repository
-git clone <repository-url>
-cd quickbuild14-containerization
+### What Each Configuration Provides:
 
-# Copy environment template
-cp .env.example .env
+**Base (docker-compose.yml):**
+- All core services (database, server, agents)
+- Basic networking and volumes
+- Standard resource limits
 
-# Edit .env with your configuration
-# (Update passwords and settings)
+**Development (docker-compose.dev.yml):**
+- Exposed database port (1433) for debugging
+- JVM debug port (5005) for remote debugging
+- DEBUG log level
+- Lower resource limits (faster startup)
+- Local volume mounts for live development
 
-# Start the stack (when implementation complete)
-docker-compose up -d
-```
+**Production (docker-compose.prod.yml):**
+- Docker secrets for password management
+- TLS/SSL support
+- Higher resource limits and reservations
+- Production restart policies
+- External volume mounts for persistence
+
+**Scaling (docker-compose.scale.yml):**
+- Replicated agent deployment
+- Rolling update strategies
+- Node placement constraints
+- Advanced failure handling
 
 ## 📁 Project Structure
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,8 +2,6 @@
 # Extends docker-compose.yml with development-specific configurations
 # Includes debugging, volume mounts, and development conveniences
 
-version: '3.8'
-
 services:
   # Database with development settings
   qb-database:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,8 +2,6 @@
 # Extends docker-compose.yml with production-specific configurations
 # Includes secrets management, resource limits, and security enhancements
 
-version: '3.8'
-
 services:
   # Database with secrets and production settings
   qb-database:

--- a/docker-compose.scale.yml
+++ b/docker-compose.scale.yml
@@ -2,8 +2,6 @@
 # Provides advanced scaling capabilities for build agents
 # Use with docker-compose.yml as base configuration
 
-version: '3.8'
-
 services:
   # Scalable Base Agents
   qb-agent-base:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@
 # Complete Docker Compose orchestration for development and small production deployments
 # Includes database, server, and scalable build agents
 
-version: '3.8'
-
 services:
   # Microsoft SQL Server Database
   qb-database:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -42,6 +42,15 @@ This guide provides detailed deployment procedures for QuickBuild 14 containeriz
 
 ## Docker Compose Deployment
 
+This project includes **4 docker-compose configurations** that work together:
+
+| File | Purpose | Usage |
+|------|---------|-------|
+| `docker-compose.yml` | Base configuration | **Always required** |
+| `docker-compose.dev.yml` | Development overrides | Use with base for dev |
+| `docker-compose.prod.yml` | Production overrides | Use with base for prod |
+| `docker-compose.scale.yml` | Scaling configuration | Use with base for scaling |
+
 ### Development Environment
 
 Perfect for development, testing, and small teams.
@@ -73,12 +82,19 @@ QB_SERVER_PORT=8810
 
 #### 3. Deploy Development Stack
 
+**Development mode** includes:
+- Database port exposed on 1433 (for external DB tools)
+- JVM debug port on 5005 (for remote debugging)
+- DEBUG log levels
+- Lower resource limits for faster startup
+- Local directory volume mounts
+
 ```bash
 # Start with development configuration
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 # Check status
-docker-compose ps
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml ps
 ```
 
 #### 4. Validate Deployment
@@ -94,6 +110,14 @@ curl -f http://localhost:8810
 ### Production Environment
 
 For production deployments with enhanced security and performance.
+
+**Production mode** includes:
+- Docker secrets for password management (no plaintext passwords)
+- TLS/SSL certificate support
+- Higher resource limits and reservations
+- Production-grade restart policies
+- External volume mounts for data persistence
+- Multiple agent replicas by default
 
 #### 1. Create Secrets
 
@@ -128,9 +152,49 @@ QB_LOG_LEVEL=WARN
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
 # Verify all services are healthy
-docker-compose ps
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml ps
 ./scripts/validate-deployment.sh -e docker-compose
 ```
+
+### Scaling Environment
+
+For high-load environments requiring advanced scaling capabilities.
+
+**Scaling mode** includes:
+- Replicated deployment mode for all agents
+- Rolling update strategies (zero-downtime updates)
+- Intelligent failure handling and rollback
+- Node placement constraints
+- Per-node replica limits
+
+#### Deploy with Scaling
+
+```bash
+# Set replica counts in .env
+export AGENT_MAVEN_REPLICAS=3
+export AGENT_NODE_REPLICAS=2
+export AGENT_DOTNET_REPLICAS=2
+
+# Start with scaling configuration
+docker-compose -f docker-compose.yml -f docker-compose.scale.yml up -d
+
+# Check scaled agents
+docker-compose -f docker-compose.yml -f docker-compose.scale.yml ps
+```
+
+### Basic Mode (Testing Only)
+
+**Not recommended for regular use.** The base configuration alone provides:
+- All services with default settings
+- Standard resource limits
+- Basic networking
+
+```bash
+# Start with base configuration only
+docker-compose up -d
+```
+
+> **⚠️ Warning:** This mode is only suitable for quick testing. Always use dev or prod overlays for actual work.
 
 ## Kubernetes Deployment
 

--- a/docs/QUICK-START-SIMPLIFIED.md
+++ b/docs/QUICK-START-SIMPLIFIED.md
@@ -47,8 +47,15 @@ sudo chmod +x /usr/local/bin/docker-compose
 git clone <your-repo>
 cd quickbuild-mcp
 
-# Quick test with simplified setup
-docker-compose -f docker-compose.simple.yml up -d
+# Configure environment
+cp .env.example .env
+# Edit .env with your passwords
+
+# Quick test with development setup
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+
+# Check status
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml ps
 ```
 
 ### Option 3: Kubernetes Testing

--- a/qb-agent/dotnet/Dockerfile
+++ b/qb-agent/dotnet/Dockerfile
@@ -54,17 +54,8 @@ ENV DOTNET_CLI_HOME=/opt/qb-agent/.dotnet
 ENV NUGET_PACKAGES=/opt/qb-agent/.nuget/packages
 
 # Create NuGet configuration
-RUN mkdir -p /opt/qb-agent/.nuget && \
-    echo '<?xml version="1.0" encoding="utf-8"?>' > /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '<configuration>' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '  <packageSources>' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '  </packageSources>' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '  <config>' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '    <add key="globalPackagesFolder" value="/opt/qb-agent/.nuget/packages" />' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '    <add key="repositoryPath" value="/opt/qb-agent/.nuget/packages" />' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '  </config>' >> /opt/qb-agent/.nuget/NuGet.Config && \
-    echo '</configuration>' >> /opt/qb-agent/.nuget/NuGet.Config
+RUN mkdir -p /opt/qb-agent/.nuget
+COPY --chown=qbagent:qbagent ./qb-agent/dotnet/config/NuGet.Config /opt/qb-agent/.nuget/NuGet.Config
 
 # Install common .NET tools
 RUN dotnet tool install --global dotnet-ef && \
@@ -84,32 +75,10 @@ RUN cd /tmp && \
     rm -rf /tmp/SampleApp
 
 # Create global.json for consistent SDK version
-RUN echo '{' > /opt/qb-agent/global.json && \
-    echo '  "sdk": {' >> /opt/qb-agent/global.json && \
-    echo '    "version": "6.0.0",' >> /opt/qb-agent/global.json && \
-    echo '    "rollForward": "latestMinor"' >> /opt/qb-agent/global.json && \
-    echo '  }' >> /opt/qb-agent/global.json && \
-    echo '}' >> /opt/qb-agent/global.json
+COPY --chown=qbagent:qbagent ./qb-agent/dotnet/config/global.json /opt/qb-agent/global.json
 
 # Create .NET-specific entrypoint script
-RUN echo '#!/bin/bash' > /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '# .NET Agent Entrypoint - sets up .NET environment and starts agent' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '# Display .NET information' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'echo ".NET SDK Version: $(dotnet --version)"' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'echo ".NET Runtime Versions:"' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'dotnet --list-runtimes' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'echo ".NET SDK Versions:"' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'dotnet --list-sdks' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '# Set up .NET environment' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'export DOTNET_CLI_HOME=/opt/qb-agent/.dotnet' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'export NUGET_PACKAGES=/opt/qb-agent/.nuget/packages' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo '# Call original agent entrypoint' >> /opt/qb-agent/dotnet-entrypoint.sh && \
-    echo 'exec /opt/qb-agent/agent-entrypoint.sh "$@"' >> /opt/qb-agent/dotnet-entrypoint.sh
-
-RUN chmod +x /opt/qb-agent/dotnet-entrypoint.sh
+COPY --chown=qbagent:qbagent --chmod=755 ./qb-agent/dotnet/config/dotnet-entrypoint.sh /opt/qb-agent/dotnet-entrypoint.sh
 
 # Verify .NET installation
 RUN dotnet --version && \

--- a/qb-agent/dotnet/Dockerfile
+++ b/qb-agent/dotnet/Dockerfile
@@ -55,18 +55,16 @@ ENV NUGET_PACKAGES=/opt/qb-agent/.nuget/packages
 
 # Create NuGet configuration
 RUN mkdir -p /opt/qb-agent/.nuget && \
-    cat > /opt/qb-agent/.nuget/NuGet.Config << 'EOF'
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-  <config>
-    <add key="globalPackagesFolder" value="/opt/qb-agent/.nuget/packages" />
-    <add key="repositoryPath" value="/opt/qb-agent/.nuget/packages" />
-  </config>
-</configuration>
-EOF
+    echo '<?xml version="1.0" encoding="utf-8"?>' > /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '<configuration>' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '  <packageSources>' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '  </packageSources>' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '  <config>' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '    <add key="globalPackagesFolder" value="/opt/qb-agent/.nuget/packages" />' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '    <add key="repositoryPath" value="/opt/qb-agent/.nuget/packages" />' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '  </config>' >> /opt/qb-agent/.nuget/NuGet.Config && \
+    echo '</configuration>' >> /opt/qb-agent/.nuget/NuGet.Config
 
 # Install common .NET tools
 RUN dotnet tool install --global dotnet-ef && \
@@ -86,34 +84,30 @@ RUN cd /tmp && \
     rm -rf /tmp/SampleApp
 
 # Create global.json for consistent SDK version
-RUN cat > /opt/qb-agent/global.json << 'EOF'
-{
-  "sdk": {
-    "version": "6.0.0",
-    "rollForward": "latestMinor"
-  }
-}
-EOF
+RUN echo '{' > /opt/qb-agent/global.json && \
+    echo '  "sdk": {' >> /opt/qb-agent/global.json && \
+    echo '    "version": "6.0.0",' >> /opt/qb-agent/global.json && \
+    echo '    "rollForward": "latestMinor"' >> /opt/qb-agent/global.json && \
+    echo '  }' >> /opt/qb-agent/global.json && \
+    echo '}' >> /opt/qb-agent/global.json
 
 # Create .NET-specific entrypoint script
-RUN cat > /opt/qb-agent/dotnet-entrypoint.sh << 'EOF'
-#!/bin/bash
-# .NET Agent Entrypoint - sets up .NET environment and starts agent
-
-# Display .NET information
-echo ".NET SDK Version: $(dotnet --version)"
-echo ".NET Runtime Versions:"
-dotnet --list-runtimes
-echo ".NET SDK Versions:"
-dotnet --list-sdks
-
-# Set up .NET environment
-export DOTNET_CLI_HOME=/opt/qb-agent/.dotnet
-export NUGET_PACKAGES=/opt/qb-agent/.nuget/packages
-
-# Call original agent entrypoint
-exec /opt/qb-agent/agent-entrypoint.sh "$@"
-EOF
+RUN echo '#!/bin/bash' > /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '# .NET Agent Entrypoint - sets up .NET environment and starts agent' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '# Display .NET information' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'echo ".NET SDK Version: $(dotnet --version)"' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'echo ".NET Runtime Versions:"' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'dotnet --list-runtimes' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'echo ".NET SDK Versions:"' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'dotnet --list-sdks' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '# Set up .NET environment' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'export DOTNET_CLI_HOME=/opt/qb-agent/.dotnet' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'export NUGET_PACKAGES=/opt/qb-agent/.nuget/packages' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo '# Call original agent entrypoint' >> /opt/qb-agent/dotnet-entrypoint.sh && \
+    echo 'exec /opt/qb-agent/agent-entrypoint.sh "$@"' >> /opt/qb-agent/dotnet-entrypoint.sh
 
 RUN chmod +x /opt/qb-agent/dotnet-entrypoint.sh
 

--- a/qb-agent/dotnet/config/NuGet.Config
+++ b/qb-agent/dotnet/config/NuGet.Config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="/opt/qb-agent/.nuget/packages" />
+    <add key="repositoryPath" value="/opt/qb-agent/.nuget/packages" />
+  </config>
+</configuration>

--- a/qb-agent/dotnet/config/dotnet-entrypoint.sh
+++ b/qb-agent/dotnet/config/dotnet-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# .NET Agent Entrypoint - sets up .NET environment and starts agent
+
+# Display .NET information
+echo ".NET SDK Version: $(dotnet --version)"
+echo ".NET Runtime Versions:"
+dotnet --list-runtimes
+echo ".NET SDK Versions:"
+dotnet --list-sdks
+
+# Set up .NET environment
+export DOTNET_CLI_HOME=/opt/qb-agent/.dotnet
+export NUGET_PACKAGES=/opt/qb-agent/.nuget/packages
+
+# Call original agent entrypoint
+exec /opt/qb-agent/agent-entrypoint.sh "$@"

--- a/qb-agent/dotnet/config/global.json
+++ b/qb-agent/dotnet/config/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMinor"
+  }
+}

--- a/qb-agent/maven/Dockerfile
+++ b/qb-agent/maven/Dockerfile
@@ -36,44 +36,42 @@ RUN mkdir -p /opt/qb-agent/.m2 && \
 
 # Create Maven settings.xml with optimized configuration
 RUN mkdir -p /opt/qb-agent/.m2 && \
-    cat > /opt/qb-agent/.m2/settings.xml << 'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 
-                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  
-  <!-- Local repository path -->
-  <localRepository>/opt/qb-agent/.m2/repository</localRepository>
-  
-  <!-- Offline mode -->
-  <offline>false</offline>
-  
-  <!-- Plugin groups -->
-  <pluginGroups>
-    <pluginGroup>org.apache.maven.plugins</pluginGroup>
-    <pluginGroup>org.codehaus.mojo</pluginGroup>
-  </pluginGroups>
-  
-  <!-- Profiles for different environments -->
-  <profiles>
-    <profile>
-      <id>quickbuild</id>
-      <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      </properties>
-    </profile>
-  </profiles>
-  
-  <!-- Active profiles -->
-  <activeProfiles>
-    <activeProfile>quickbuild</activeProfile>
-  </activeProfiles>
-  
-</settings>
-EOF
+    echo '<?xml version="1.0" encoding="UTF-8"?>' > /opt/qb-agent/.m2/settings.xml && \
+    echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '                              http://maven.apache.org/xsd/settings-1.0.0.xsd">' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <!-- Local repository path -->' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <localRepository>/opt/qb-agent/.m2/repository</localRepository>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <!-- Offline mode -->' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <offline>false</offline>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <!-- Plugin groups -->' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <pluginGroups>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '    <pluginGroup>org.apache.maven.plugins</pluginGroup>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '    <pluginGroup>org.codehaus.mojo</pluginGroup>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  </pluginGroups>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <!-- Profiles for different environments -->' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <profiles>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '    <profile>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '      <id>quickbuild</id>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '      <properties>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '        <maven.compiler.source>8</maven.compiler.source>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '        <maven.compiler.target>8</maven.compiler.target>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '      </properties>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '    </profile>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  </profiles>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <!-- Active profiles -->' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  <activeProfiles>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '    <activeProfile>quickbuild</activeProfile>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  </activeProfiles>' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
+    echo '</settings>' >> /opt/qb-agent/.m2/settings.xml
 
 # Set proper ownership
 RUN chown -R qbagent:qbagent /opt/qb-agent/.m2

--- a/qb-agent/maven/Dockerfile
+++ b/qb-agent/maven/Dockerfile
@@ -35,46 +35,7 @@ RUN mkdir -p /opt/qb-agent/.m2 && \
     chown -R qbagent:qbagent /opt/qb-agent/.m2
 
 # Create Maven settings.xml with optimized configuration
-RUN mkdir -p /opt/qb-agent/.m2 && \
-    echo '<?xml version="1.0" encoding="UTF-8"?>' > /opt/qb-agent/.m2/settings.xml && \
-    echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '                              http://maven.apache.org/xsd/settings-1.0.0.xsd">' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <!-- Local repository path -->' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <localRepository>/opt/qb-agent/.m2/repository</localRepository>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <!-- Offline mode -->' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <offline>false</offline>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <!-- Plugin groups -->' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <pluginGroups>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '    <pluginGroup>org.apache.maven.plugins</pluginGroup>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '    <pluginGroup>org.codehaus.mojo</pluginGroup>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  </pluginGroups>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <!-- Profiles for different environments -->' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <profiles>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '    <profile>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '      <id>quickbuild</id>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '      <properties>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '        <maven.compiler.source>8</maven.compiler.source>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '        <maven.compiler.target>8</maven.compiler.target>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '      </properties>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '    </profile>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  </profiles>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <!-- Active profiles -->' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  <activeProfiles>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '    <activeProfile>quickbuild</activeProfile>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  </activeProfiles>' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '  ' >> /opt/qb-agent/.m2/settings.xml && \
-    echo '</settings>' >> /opt/qb-agent/.m2/settings.xml
-
-# Set proper ownership
-RUN chown -R qbagent:qbagent /opt/qb-agent/.m2
+COPY --chown=qbagent:qbagent ./qb-agent/maven/config/settings.xml /opt/qb-agent/.m2/settings.xml
 
 # Verify Maven installation
 RUN mvn --version

--- a/qb-agent/maven/config/settings.xml
+++ b/qb-agent/maven/config/settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- Local repository path -->
+  <localRepository>/opt/qb-agent/.m2/repository</localRepository>
+
+  <!-- Offline mode -->
+  <offline>false</offline>
+
+  <!-- Plugin groups -->
+  <pluginGroups>
+    <pluginGroup>org.apache.maven.plugins</pluginGroup>
+    <pluginGroup>org.codehaus.mojo</pluginGroup>
+  </pluginGroups>
+
+  <!-- Profiles for different environments -->
+  <profiles>
+    <profile>
+      <id>quickbuild</id>
+      <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      </properties>
+    </profile>
+  </profiles>
+
+  <!-- Active profiles -->
+  <activeProfiles>
+    <activeProfile>quickbuild</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/qb-agent/node/Dockerfile
+++ b/qb-agent/node/Dockerfile
@@ -71,41 +71,14 @@ RUN bash -c "source $NVM_DIR/nvm.sh && \
     echo '✓ Global packages installed successfully'"
 
 # Create npm configuration for optimized builds
-RUN mkdir -p /opt/qb-agent/.npm && \
-    echo '# NPM Configuration for QuickBuild Agent' > /opt/qb-agent/.npmrc && \
-    echo 'cache=/opt/qb-agent/.npm' >> /opt/qb-agent/.npmrc && \
-    echo 'prefix=/opt/qb-agent/.npm-global' >> /opt/qb-agent/.npmrc && \
-    echo 'init-author-name=QuickBuild Agent' >> /opt/qb-agent/.npmrc && \
-    echo 'init-license=MIT' >> /opt/qb-agent/.npmrc && \
-    echo 'save-exact=true' >> /opt/qb-agent/.npmrc && \
-    echo 'engine-strict=true' >> /opt/qb-agent/.npmrc && \
-    echo 'fund=false' >> /opt/qb-agent/.npmrc && \
-    echo 'audit-level=moderate' >> /opt/qb-agent/.npmrc
+RUN mkdir -p /opt/qb-agent/.npm
+COPY --chown=qbagent:qbagent ./qb-agent/node/config/.npmrc /opt/qb-agent/.npmrc
 
 # Set up npm global directory
 ENV PATH=/opt/qb-agent/.npm-global/bin:$PATH
 
 # Create entrypoint script that sources NVM
-RUN echo '#!/bin/bash' > /opt/qb-agent/node-entrypoint.sh && \
-    echo '# Node.js Agent Entrypoint - sources NVM and starts agent' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '# Source NVM' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo 'export NVM_DIR="/opt/qb-agent/.nvm"' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '# Use default Node version' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo 'nvm use default' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '# Display Node.js information' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo 'echo "Node.js Version: $(node --version)"' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo 'echo "NPM Version: $(npm --version)"' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo 'echo "Yarn Version: $(yarn --version)"' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo '# Call original agent entrypoint' >> /opt/qb-agent/node-entrypoint.sh && \
-    echo 'exec /opt/qb-agent/agent-entrypoint.sh "$@"' >> /opt/qb-agent/node-entrypoint.sh
-
-RUN chmod +x /opt/qb-agent/node-entrypoint.sh
+COPY --chown=qbagent:qbagent --chmod=755 ./qb-agent/node/config/node-entrypoint.sh /opt/qb-agent/node-entrypoint.sh
 
 # Verify installations
 RUN bash -c "source $NVM_DIR/nvm.sh && \

--- a/qb-agent/node/Dockerfile
+++ b/qb-agent/node/Dockerfile
@@ -72,42 +72,38 @@ RUN bash -c "source $NVM_DIR/nvm.sh && \
 
 # Create npm configuration for optimized builds
 RUN mkdir -p /opt/qb-agent/.npm && \
-    cat > /opt/qb-agent/.npmrc << 'EOF'
-# NPM Configuration for QuickBuild Agent
-cache=/opt/qb-agent/.npm
-prefix=/opt/qb-agent/.npm-global
-init-author-name=QuickBuild Agent
-init-license=MIT
-save-exact=true
-engine-strict=true
-fund=false
-audit-level=moderate
-EOF
+    echo '# NPM Configuration for QuickBuild Agent' > /opt/qb-agent/.npmrc && \
+    echo 'cache=/opt/qb-agent/.npm' >> /opt/qb-agent/.npmrc && \
+    echo 'prefix=/opt/qb-agent/.npm-global' >> /opt/qb-agent/.npmrc && \
+    echo 'init-author-name=QuickBuild Agent' >> /opt/qb-agent/.npmrc && \
+    echo 'init-license=MIT' >> /opt/qb-agent/.npmrc && \
+    echo 'save-exact=true' >> /opt/qb-agent/.npmrc && \
+    echo 'engine-strict=true' >> /opt/qb-agent/.npmrc && \
+    echo 'fund=false' >> /opt/qb-agent/.npmrc && \
+    echo 'audit-level=moderate' >> /opt/qb-agent/.npmrc
 
 # Set up npm global directory
 ENV PATH=/opt/qb-agent/.npm-global/bin:$PATH
 
 # Create entrypoint script that sources NVM
-RUN cat > /opt/qb-agent/node-entrypoint.sh << 'EOF'
-#!/bin/bash
-# Node.js Agent Entrypoint - sources NVM and starts agent
-
-# Source NVM
-export NVM_DIR="/opt/qb-agent/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-
-# Use default Node version
-nvm use default
-
-# Display Node.js information
-echo "Node.js Version: $(node --version)"
-echo "NPM Version: $(npm --version)"
-echo "Yarn Version: $(yarn --version)"
-
-# Call original agent entrypoint
-exec /opt/qb-agent/agent-entrypoint.sh "$@"
-EOF
+RUN echo '#!/bin/bash' > /opt/qb-agent/node-entrypoint.sh && \
+    echo '# Node.js Agent Entrypoint - sources NVM and starts agent' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '# Source NVM' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo 'export NVM_DIR="/opt/qb-agent/.nvm"' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '# Use default Node version' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo 'nvm use default' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '# Display Node.js information' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo 'echo "Node.js Version: $(node --version)"' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo 'echo "NPM Version: $(npm --version)"' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo 'echo "Yarn Version: $(yarn --version)"' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo '# Call original agent entrypoint' >> /opt/qb-agent/node-entrypoint.sh && \
+    echo 'exec /opt/qb-agent/agent-entrypoint.sh "$@"' >> /opt/qb-agent/node-entrypoint.sh
 
 RUN chmod +x /opt/qb-agent/node-entrypoint.sh
 

--- a/qb-agent/node/config/.npmrc
+++ b/qb-agent/node/config/.npmrc
@@ -1,0 +1,9 @@
+# NPM Configuration for QuickBuild Agent
+cache=/opt/qb-agent/.npm
+prefix=/opt/qb-agent/.npm-global
+init-author-name=QuickBuild Agent
+init-license=MIT
+save-exact=true
+engine-strict=true
+fund=false
+audit-level=moderate

--- a/qb-agent/node/config/node-entrypoint.sh
+++ b/qb-agent/node/config/node-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Node.js Agent Entrypoint - sources NVM and starts agent
+
+# Source NVM
+export NVM_DIR="/opt/qb-agent/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+# Use default Node version
+nvm use default
+
+# Display Node.js information
+echo "Node.js Version: $(node --version)"
+echo "NPM Version: $(npm --version)"
+echo "Yarn Version: $(yarn --version)"
+
+# Call original agent entrypoint
+exec /opt/qb-agent/agent-entrypoint.sh "$@"


### PR DESCRIPTION
…tion

This commit addresses multiple issues with docker-compose configurations and Dockerfiles:

## Docker-compose Fixes:
- Remove obsolete 'version' attribute from all docker-compose files (3.8 no longer needed)
- Fixes warnings: "the attribute 'version' is obsolete, it will be ignored"

## Dockerfile Fixes:
- Replace heredoc syntax with echo statements in all agent Dockerfiles
- Fixes parse error: "unknown instruction: <?xml" in dotnet/maven/node agents
- Updated files:
  - qb-agent/dotnet/Dockerfile (NuGet.Config, global.json, entrypoint script)
  - qb-agent/maven/Dockerfile (settings.xml)
  - qb-agent/node/Dockerfile (.npmrc, entrypoint script)

## Documentation Updates:
- README.md: Added clear explanation of 4 docker-compose configurations with usage table
- README.md: Updated Quick Start with deployment mode options (Dev/Prod/Scale/Basic)
- DEPLOYMENT.md: Added comprehensive docker-compose configuration guide
- DEPLOYMENT.md: Documented what each mode provides (dev/prod/scale/basic)
- QUICK-START-SIMPLIFIED.md: Fixed reference to non-existent docker-compose.simple.yml

## Testing:
- All YAML files validated with Python yaml parser
- All Dockerfiles validated for syntax issues
- No heredoc remnants detected in modified files

This ensures users understand which docker-compose command to use for their scenario:
- Development: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
- Production: docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
- Scaling: docker-compose -f docker-compose.yml -f docker-compose.scale.yml up -d
- Basic: docker-compose up -d (testing only)